### PR TITLE
ove package location has changed

### DIFF
--- a/.github/workflows/republish_ove_umd_files.yml
+++ b/.github/workflows/republish_ove_umd_files.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   get_versions:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       ove_umd_version: ${{ steps.setver.outputs.ove_umd_version }}
       ove_version:  ${{ steps.setver.outputs.ove_version }}
@@ -15,37 +15,37 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: set versions
         id: setver
         run: |
-          echo "ove_umd_version=$(node -pe "require('./open-vector-editor-umd/package.json').version")" >> $GITHUB_OUTPUT
-          echo "ove_version=$(npm view open-vector-editor version)" >> $GITHUB_OUTPUT
+          echo "ove_umd_version=$(node -pe "require('./tg-oss-ove-umd/package.json').version")" >> $GITHUB_OUTPUT
+          echo "ove_version=$(npm view @teselagen/ove version)" >> $GITHUB_OUTPUT
 
   publish:
     needs: [get_versions]
     if: needs.get_versions.outputs.ove_umd_version < needs.get_versions.outputs.ove_version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
 
       - name: Install latest OVE
-        run: npm install open-vector-editor@${{ needs.get_versions.outputs.ove_version }} --silent
+        run: npm install @teselagen/ove@${{ needs.get_versions.outputs.ove_version }} --silent
 
       - name: Copy umd files
-        run: cp node_modules/open-vector-editor/umd/* open-vector-editor-umd/
+        run: bash -c 'cp node_modules/@teselagen/ove/{index.umd.js,style.css} tg-oss-ove-umd/
 
       - name: Update package version
         run: npm version --allow-same-version ${{ needs.get_versions.outputs.ove_version }}
-        working-directory: ./open-vector-editor-umd
+        working-directory: ./tg-oss-ove-umd
 
-      - name: "Publish @deltablot/open-vector-editor-umd"
+      - name: "Publish @deltablot/tg-oss-ove-umd"
         run: npm publish --access public
-        working-directory: ./open-vector-editor-umd
+        working-directory: ./tg-oss-ove-umd
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
         run: |
           shopt -s extglob
           rm -rf !('package.json'|'README.md')
-        working-directory: ./open-vector-editor-umd
+        working-directory: ./tg-oss-ove-umd
 
       - name: Commit new version
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deltablot/ove-umd-builder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Helper to publish only the umd files of open-vector-editor",
   "author": "Marcel Bolten",
   "contributors": [
@@ -8,6 +8,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "open-vector-editor": "^18.3.6"
+    "@teselagen/ove": "^0.0.1"
   }
 }

--- a/tg-oss-ove-umd/README.md
+++ b/tg-oss-ove-umd/README.md
@@ -1,15 +1,10 @@
-# OVE-UMD-Builder
+# tg-oss-ove-umd
+
+The tg-oss-ove-umd package contains only the UMD files of [open-vector-editor](https://www.npmjs.com/package/@teselagen/ove).
 
 [Open Vector Editor](https://github.com/TeselaGen/tg-oss/tree/main/packages/ove) is Teselagen's Open Source Vector/Plasmid Editor Component that uses React and Redux. It is published as [@teselagen/ove in the npm registry](https://www.npmjs.com/package/@teselagen/ove). However, if your project does not use React and Redux, open-vector-editor will add a lot of dependencies.
 
 Fortunately, open-vector-editor also has a universal build (Universal Module Definition, UMD).
 
-This is a little helper repository to republish only the UMD files via github actions in a new package [@deltablot/tg-oss-ove-umd](https://www.npmjs.com/package/@deltablot/tg-oss-ove-umd):
-
-- check for new OVE version
-- download files if new version is available
-- extract umd files
-- republish umd files as open-vector-editor-umd package
-
-The files are republished as they are without further testing.
+The files are republish as they are without further testing.
 If you have problems with Open Vector Editor please seek help from the OVE developers at https://github.com/TeselaGen/tg-oss/tree/main/packages/ove.

--- a/tg-oss-ove-umd/package.json
+++ b/tg-oss-ove-umd/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@deltablot/tg-oss-ove-umd",
+  "version": "0.0.1",
+  "description": "UMD files for open vector editor",
+  "main": "index.umd.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deltablot/ove-umd-builder.git"
+  },
+  "keywords": [
+    "plasmid",
+    "editor"
+  ],
+  "author": "Marcel Bolten",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/deltablot/ove-umd-builder/issues"
+  },
+  "homepage": "https://github.com/deltablot/ove-umd-builder#readme"
+}


### PR DESCRIPTION
Hi @NicolasCARPi

The location of the OVE package has changed. Now it can be found under [@teselagen/ove](https://www.npmjs.com/package/@teselagen/ove) and https://github.com/TeselaGen/tg-oss/tree/main/packages/ove.

Update for eLabFTW will follow soon but this need to be working first.